### PR TITLE
android: give the adapter name back, and let it settle before advertising

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,32 @@ All notable changes to `blew` are documented here. Format follows
   with `call_static_method`, which found no matching static method and
   panicked, aborting the process. Every other Rust-called method in these
   files already carried `@JvmStatic`; `init` was the one omission.
+- **Android: the adapter name is given back when advertising stops.**
+  `startAdvertising` overwrote `BluetoothAdapter.name` and never restored it,
+  so the beacon name outlived the process: the handset kept answering to it in
+  the car, in the headphones and in every pairing dialog, and still did after
+  the app was uninstalled. The name in place beforehand is now remembered and
+  put back in `stopAdvertising`.
+
+- **Android: the first advertisement after an install no longer fails.**
+  A new adapter name is applied asynchronously, but the scan response carries
+  whatever name is in place when advertising starts — so setting the name and
+  advertising in the same breath went out under the old one, and an old name
+  long enough to overflow the 31-byte scan response failed the advertisement
+  with `ADVERTISE_FAILED_DATA_TOO_LARGE`. It struck once per fresh install,
+  and permanently on a device whose owner writes in a non-Latin script.
+  Advertising now waits for `ACTION_LOCAL_NAME_CHANGED`, with a one-second
+  backstop for a broadcast that never arrives.
+
+### Changed
+
+- **An empty `AdvertisingConfig::local_name` now advertises no name.** It
+  previously advertised an empty one — a `CBAdvertisementDataLocalNameKey` and
+  a BlueZ `LocalName` holding nothing, and on Android the adapter's own name
+  overwritten with the empty string and `setIncludeDeviceName(true)` on top.
+  Leaving the handset's name alone was not expressible, and it is the only
+  name it has: there is no per-advertisement name on Android. A peer that
+  identifies itself through service data rather than a name can now say so.
 
 ## [0.4.0-beta.1] — 2026-09-01
 

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -16,11 +16,13 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.CountDownLatch
 import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicBoolean
 
 /**
  * Singleton managing the Android BLE peripheral role (GATT server + advertiser).
@@ -428,6 +430,17 @@ object BlePeripheralManager {
     private var advertiseRequestId: Int = 0
 
     /**
+     * The adapter name as its owner had it, held while a beacon name of ours is
+     * in its place. This is the phone's Bluetooth name everywhere -- in the car,
+     * in the headphones, in every pairing dialog -- so it is given back in
+     * [stopAdvertising] rather than left behind.
+     */
+    private var nameBeforeAdvertising: String? = null
+
+    /** Backstop for a [BluetoothAdapter.ACTION_LOCAL_NAME_CHANGED] that never arrives. */
+    private const val NAME_APPLIED_WITHIN_MS = 1_000L
+
+    /**
      * Begin advertising. Returns [ADVERTISE_OK] when the request was handed to
      * the stack, or a failure code for something that went wrong before that.
      *
@@ -465,8 +478,6 @@ object BlePeripheralManager {
         advertiser = adv
         advertiseRequestId = requestId
 
-        bluetoothManager?.adapter?.name = name
-
         val settings =
             AdvertiseSettings
                 .Builder()
@@ -488,7 +499,7 @@ object BlePeripheralManager {
         val scanResponse =
             AdvertiseData
                 .Builder()
-                .setIncludeDeviceName(true)
+                .setIncludeDeviceName(name.isNotEmpty())
                 .build()
 
         advertiseCallback =
@@ -513,8 +524,59 @@ object BlePeripheralManager {
                 }
             }
 
-        adv.startAdvertising(settings, data, scanResponse, advertiseCallback)
+        takeTheNameThenAdvertise(adv, name, settings, data, scanResponse, advertiseCallback)
         return ADVERTISE_OK
+    }
+
+    /**
+     * Android applies a new adapter name asynchronously, and the scan response
+     * carries whatever name is in place when advertising starts. Setting the
+     * name and advertising in the same breath therefore goes out under the old
+     * one, and an old name long enough to overflow the scan response fails the
+     * advertisement outright with `ADVERTISE_FAILED_DATA_TOO_LARGE` -- once, on
+     * the first session after an install, which is the hardest one to catch.
+     */
+    private fun takeTheNameThenAdvertise(
+        adv: BluetoothLeAdvertiser,
+        name: String,
+        settings: AdvertiseSettings,
+        data: AdvertiseData,
+        scanResponse: AdvertiseData,
+        callback: AdvertiseCallback?,
+    ) {
+        val adapter = bluetoothManager?.adapter
+        val ctx = context
+        val adapterKeepsItsOwnName = name.isEmpty()
+        if (adapterKeepsItsOwnName || adapter == null || ctx == null || adapter.name == name) {
+            adv.startAdvertising(settings, data, scanResponse, callback)
+            return
+        }
+        if (nameBeforeAdvertising == null) {
+            nameBeforeAdvertising = adapter.name
+        }
+        val started = AtomicBoolean(false)
+        var applied: BroadcastReceiver? = null
+        val advertiseOnce = {
+            if (started.compareAndSet(false, true)) {
+                applied?.let { runCatching { ctx.unregisterReceiver(it) } }
+                adv.startAdvertising(settings, data, scanResponse, callback)
+            }
+        }
+        applied =
+            object : BroadcastReceiver() {
+                override fun onReceive(
+                    unused: Context,
+                    intent: Intent,
+                ) {
+                    if (adapter.name == name) advertiseOnce()
+                }
+            }
+        ctx.registerReceiver(applied, IntentFilter(BluetoothAdapter.ACTION_LOCAL_NAME_CHANGED))
+        adapter.name = name
+        scope.launch {
+            delay(NAME_APPLIED_WITHIN_MS)
+            advertiseOnce()
+        }
     }
 
     @JvmStatic
@@ -523,6 +585,10 @@ object BlePeripheralManager {
             advertiseCallback?.let { cb ->
                 advertiser?.stopAdvertising(cb)
                 advertiseCallback = null
+            }
+            nameBeforeAdvertising?.let { theirs ->
+                bluetoothManager?.adapter?.name = theirs
+                nameBeforeAdvertising = null
             }
         }
         Log.d(TAG, "advertising stopped")

--- a/crates/blew/src/platform/apple/peripheral.rs
+++ b/crates/blew/src/platform/apple/peripheral.rs
@@ -885,7 +885,13 @@ impl PeripheralBackend for ApplePeripheral {
                 let ln_any: &AnyObject = &local_name;
                 let ua_any: &AnyObject = &uuid_array;
 
-                let adv_data = NSDictionary::from_slices(&[key_name, key_uuids], &[ln_any, ua_any]);
+                let mut keys = vec![key_uuids];
+                let mut values = vec![ua_any];
+                if !config.local_name.is_empty() {
+                    keys.push(key_name);
+                    values.push(ln_any);
+                }
+                let adv_data = NSDictionary::from_slices(&keys, &values);
 
                 let (tx, rx) = oneshot::channel();
                 *handle.inner.adv_tx.lock() = Some(tx);

--- a/crates/blew/src/platform/linux/peripheral.rs
+++ b/crates/blew/src/platform/linux/peripheral.rs
@@ -413,7 +413,7 @@ impl PeripheralBackend for LinuxPeripheral {
             // doesn't support extended advertising (BLE 4.x adapters).
             let make_adv = |secondary_channel| Advertisement {
                 advertisement_type: AdvType::Peripheral,
-                local_name: Some(config.local_name.clone()),
+                local_name: Some(config.local_name.clone()).filter(|it| !it.is_empty()),
                 service_uuids: config.service_uuids.clone().into_iter().collect(),
                 secondary_channel,
                 ..Default::default()

--- a/crates/blew/src/testing.rs
+++ b/crates/blew/src/testing.rs
@@ -288,7 +288,7 @@ impl CentralBackend for MockCentral {
         let tx = self.event_tx.clone();
         async move {
             if advertising {
-                let name = adv_config.map(|c| c.local_name);
+                let name = adv_config.map(|c| c.local_name).filter(|it| !it.is_empty());
                 let _ = tx.send(CentralEvent::DeviceDiscovered(BleDevice {
                     id: DeviceId::from("mock-peripheral"),
                     name,
@@ -1168,6 +1168,32 @@ mod tests {
         peripheral.start_advertising(&config).await.unwrap();
         let result = peripheral.start_advertising(&config).await;
         assert!(matches!(result, Err(BlewError::AlreadyAdvertising)));
+    }
+
+    #[tokio::test]
+    async fn an_empty_local_name_advertises_no_name_at_all() {
+        let (c, p) = MockLink::pair();
+        let peripheral = Peripheral::from_backend(p.peripheral);
+        let central = Central::from_backend(c.central);
+
+        peripheral
+            .start_advertising(&AdvertisingConfig {
+                local_name: String::new(),
+                service_uuids: vec![],
+            })
+            .await
+            .unwrap();
+        let mut events = central.events();
+        assert!(matches!(
+            events.next().await.unwrap(),
+            CentralEvent::AdapterStateChanged { powered: true }
+        ));
+        central.start_scan(ScanFilter::default()).await.unwrap();
+
+        let Some(CentralEvent::DeviceDiscovered(device)) = events.next().await else {
+            panic!("the advertisement never reached the central");
+        };
+        assert_eq!(device.name, None);
     }
 
     #[tokio::test]


### PR DESCRIPTION
Two bugs in `BlePeripheralManager.startAdvertising`, both on the one line that
assigns `BluetoothAdapter.name`. Found while embedding blew in a mesh app; the
first one reached a user's phone.

## The adapter name is never given back

`startAdvertising` sets `adapter.name` and nothing restores it. That is the
phone's Bluetooth name system-wide, so the beacon name outlives the process:
after one session a handset here answered to `RO3JHAAY` in the car, in the
headphones and in every pairing dialog — and still did once the app was gone.
Its owner had to be told what had happened to his phone.

blew is the only side that knows when the name stops being the user's and
starts being a beacon, so restoring it downstream means guessing. This
remembers the name in place before the first overwrite and puts it back in
`stopAdvertising`.

## The first advertisement after an install fails

`adapter.name = name` is applied asynchronously, while the scan response is
built from whatever name is in place when advertising starts. The first
attempt therefore goes out under the *old* name, and an old name long enough
to overflow the 31-byte scan response fails the whole advertisement:

```
E BlePeripheralManager: advertising failed: errorCode=1
```

`errorCode=1` is `ADVERTISE_FAILED_DATA_TOO_LARGE`. The name here was thirty
characters of Cyrillic — about fifty bytes in UTF-8. The second launch works,
because by then the short beacon name is already in place, so the radio is
mute for exactly one session on a fresh device, and until something restarts
the app on a device whose owner writes in a non-Latin script.

Advertising now waits for `ACTION_LOCAL_NAME_CHANGED` before starting, with a
one-second backstop so a broadcast that never arrives cannot strand it. Where
the name is already the one asked for, nothing is set and nothing is waited
for.

## Not borrowing the name at all

Both fixes above make the borrowing safe. Neither makes it optional, and an
application that identifies itself some other way — service data, a service
UUID — has no reason to touch the user's name in the first place.

An empty `local_name` now means *no name*, rather than an empty one. On
Android nothing is assigned and `setIncludeDeviceName` is off; the phone keeps
the name it had. Apple and Linux are changed to match, because a contract that
holds on one backend of three is not a contract: they previously advertised a
`CBAdvertisementDataLocalNameKey` and a BlueZ `LocalName` holding nothing.

This is a behaviour change for a caller passing `""` today and expecting an
empty name on the air. It is in the changelog under `Changed`.

## Checks

`mise run test` (95 passed), `mise run lint`, `mise run ci:compile-kotlin` and
`mise run ci:check-ios` all pass. The mock backend covers the empty-name rule
and the test fails if the rule is reverted.

Verified on hardware only for the restore path; the race is reasoned from the
failure above rather than reproduced on demand.
