### PR TITLE
advertising: carry service data where the platform allows it

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,34 @@ All notable changes to `blew` are documented here. Format follows
   panicked, aborting the process. Every other Rust-called method in these
   files already carried `@JvmStatic`; `init` was the one omission.
 
+### Added
+
+- **`AdvertisingConfig::service_data`**, payload keyed by service UUID
+  (part of #16). Android maps it to `AdvertiseData.addServiceData`, Linux to
+  bluer's `Advertisement::service_data`. It is a few bytes beside a UUID rather
+  than a second 128-bit UUID, which is what fits once the advertisement already
+  carries one.
+
+  On Android it rides in the **scan response**, alongside the name and for the
+  same reason: a 128-bit service UUID costs 18 of the advertisement's 31 bytes
+  and service data keyed by another one costs 18 more, so the two together
+  never fit and the stack answers `ADVERTISE_FAILED_DATA_TOO_LARGE`. The scan
+  response has 31 bytes of its own. Every backend here scans actively, as do
+  the platform defaults, so a scan response is delivered like any other field.
+
+  Apple is the exception, and it says so: `startAdvertising:` honours no such
+  key, so a non-empty map there is `BlewError::NotSupported` rather than an
+  advertisement quietly missing what it was told to carry. That is the same
+  reasoning that keeps manufacturer data off this struct, answered differently
+  because service data is the only remaining way to put bytes on the air, and
+  the two backends that can do it are the two where an application cannot fall
+  back to the local name — Android has no per-advertisement name, only the
+  adapter's own.
+
+  The mock backend now carries advertised service data through to the scanning
+  central, which it previously dropped; `BleDevice::service_data` was otherwise
+  untestable.
+
 ## [0.4.0-beta.1] — 2026-09-01
 
 ### Added

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -438,12 +438,19 @@ object BlePeripheralManager {
     fun startAdvertising(
         name: String,
         serviceUuids: Array<String>,
+        serviceDataUuids: Array<String>,
+        serviceDataValues: Array<ByteArray>,
         requestId: Int,
-    ): Int = synchronized(advertiseLock) { startAdvertisingLocked(name, serviceUuids, requestId) }
+    ): Int =
+        synchronized(advertiseLock) {
+            startAdvertisingLocked(name, serviceUuids, serviceDataUuids, serviceDataValues, requestId)
+        }
 
     private fun startAdvertisingLocked(
         name: String,
         serviceUuids: Array<String>,
+        serviceDataUuids: Array<String>,
+        serviceDataValues: Array<ByteArray>,
         requestId: Int,
     ): Int {
         // Android can only stop an advertisement by handing back the exact
@@ -475,21 +482,24 @@ object BlePeripheralManager {
                 .setTxPowerLevel(AdvertiseSettings.ADVERTISE_TX_POWER_HIGH)
                 .build()
 
-        val dataBuilder =
+        val thirtyOneBytesOfAdvertisement =
             AdvertiseData
                 .Builder()
                 .setIncludeDeviceName(false)
         for (uuid in serviceUuids) {
-            dataBuilder.addServiceUuid(ParcelUuid(UUID.fromString(uuid)))
+            thirtyOneBytesOfAdvertisement.addServiceUuid(ParcelUuid(UUID.fromString(uuid)))
         }
-        val data = dataBuilder.build()
 
-        // Scan response can carry the device name.
-        val scanResponse =
+        val thirtyOneMoreInTheScanResponse =
             AdvertiseData
                 .Builder()
                 .setIncludeDeviceName(true)
-                .build()
+        for ((i, uuid) in serviceDataUuids.withIndex()) {
+            thirtyOneMoreInTheScanResponse.addServiceData(
+                ParcelUuid(UUID.fromString(uuid)),
+                serviceDataValues[i],
+            )
+        }
 
         advertiseCallback =
             object : AdvertiseCallback() {
@@ -513,7 +523,12 @@ object BlePeripheralManager {
                 }
             }
 
-        adv.startAdvertising(settings, data, scanResponse, advertiseCallback)
+        adv.startAdvertising(
+            settings,
+            thirtyOneBytesOfAdvertisement.build(),
+            thirtyOneMoreInTheScanResponse.build(),
+            advertiseCallback,
+        )
         return ADVERTISE_OK
     }
 

--- a/crates/blew/examples/advertise.rs
+++ b/crates/blew/examples/advertise.rs
@@ -48,6 +48,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .start_advertising(&AdvertisingConfig {
             local_name: "blew-example".into(),
             service_uuids: vec![SVC_UUID],
+            ..Default::default()
         })
         .await?;
     println!("Advertising as \"blew-example\" for 30 s ... (Ctrl-C to stop early)");

--- a/crates/blew/examples/integration_peripheral.rs
+++ b/crates/blew/examples/integration_peripheral.rs
@@ -222,6 +222,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .start_advertising(&AdvertisingConfig {
             local_name: "blew-integration".into(),
             service_uuids: vec![SVC_UUID],
+            ..Default::default()
         })
         .await?;
     if keep_alive {

--- a/crates/blew/examples/l2cap_server.rs
+++ b/crates/blew/examples/l2cap_server.rs
@@ -57,6 +57,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .start_advertising(&AdvertisingConfig {
             local_name: "blew-l2cap".into(),
             service_uuids: vec![SVC_UUID],
+            ..Default::default()
         })
         .await?;
     println!("Advertising as \"blew-l2cap\" ... (Ctrl-C to stop)");

--- a/crates/blew/examples/restore.rs
+++ b/crates/blew/examples/restore.rs
@@ -122,6 +122,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 .start_advertising(&AdvertisingConfig {
                     local_name: "blew-restore".into(),
                     service_uuids: vec![SVC_UUID],
+                    ..Default::default()
                 })
                 .await?;
         }

--- a/crates/blew/src/peripheral/types.rs
+++ b/crates/blew/src/peripheral/types.rs
@@ -1,5 +1,6 @@
 use crate::l2cap::L2capConfig;
 use crate::types::DeviceId;
+use std::collections::BTreeMap;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
@@ -166,6 +167,10 @@ impl WriteResponder {
 pub struct AdvertisingConfig {
     pub local_name: String,
     pub service_uuids: Vec<Uuid>,
+    /// Payload per service UUID. Apple accepts no such key, so a non-empty map
+    /// there is [`BlewError::NotSupported`](crate::BlewError::NotSupported)
+    /// rather than a silent omission.
+    pub service_data: BTreeMap<Uuid, Vec<u8>>,
 }
 
 #[cfg(test)]

--- a/crates/blew/src/platform/android/peripheral.rs
+++ b/crates/blew/src/platform/android/peripheral.rs
@@ -181,6 +181,9 @@ async fn drive_advertising(
 ) -> BlewResult<()> {
     let uuid_count = i32::try_from(config.service_uuids.len())
         .map_err(|_| BlewError::Internal("too many service UUIDs in AdvertisingConfig".into()))?;
+    let data_count = i32::try_from(config.service_data.len()).map_err(|_| {
+        BlewError::Internal("too many service data entries in AdvertisingConfig".into())
+    })?;
 
     let code: i32 = jvm()
         .attach_current_thread(|env| {
@@ -194,11 +197,29 @@ async fn drive_advertising(
                 uuids.set_element(env, i, &s)?;
             }
 
+            let byte_array_class = env.find_class(jni_str!("[B"))?;
+            let data_uuids: JObjectArray =
+                env.new_object_array(data_count, &string_class, JObject::null())?;
+            let data_values: JObjectArray =
+                env.new_object_array(data_count, &byte_array_class, JObject::null())?;
+            for (i, (uuid, value)) in config.service_data.iter().enumerate() {
+                let s = env.new_string(uuid.to_string())?;
+                data_uuids.set_element(env, i, &s)?;
+                let bytes = env.byte_array_from_slice(value)?;
+                data_values.set_element(env, i, &bytes)?;
+            }
+
             env.call_static_method(
                 peripheral_class(),
                 jni_str!("startAdvertising"),
-                jni_sig!("(Ljava/lang/String;[Ljava/lang/String;I)I"),
-                &[(&name).into(), (&uuids).into(), request_id.into()],
+                jni_sig!("(Ljava/lang/String;[Ljava/lang/String;[Ljava/lang/String;[[BI)I"),
+                &[
+                    (&name).into(),
+                    (&uuids).into(),
+                    (&data_uuids).into(),
+                    (&data_values).into(),
+                    request_id.into(),
+                ],
             )?
             .i()
         })

--- a/crates/blew/src/platform/apple/peripheral.rs
+++ b/crates/blew/src/platform/apple/peripheral.rs
@@ -864,6 +864,9 @@ impl PeripheralBackend for ApplePeripheral {
         let handle = Arc::clone(&self.0);
         let config = config.clone();
         async move {
+            if !config.service_data.is_empty() {
+                return Err(BlewError::NotSupported);
+            }
             if unsafe { handle.manager.isAdvertising() } {
                 return Err(BlewError::AlreadyAdvertising);
             }

--- a/crates/blew/src/platform/linux/peripheral.rs
+++ b/crates/blew/src/platform/linux/peripheral.rs
@@ -415,6 +415,7 @@ impl PeripheralBackend for LinuxPeripheral {
                 advertisement_type: AdvType::Peripheral,
                 local_name: Some(config.local_name.clone()),
                 service_uuids: config.service_uuids.clone().into_iter().collect(),
+                service_data: config.service_data.clone().into_iter().collect(),
                 secondary_channel,
                 ..Default::default()
             };

--- a/crates/blew/src/testing.rs
+++ b/crates/blew/src/testing.rs
@@ -288,14 +288,22 @@ impl CentralBackend for MockCentral {
         let tx = self.event_tx.clone();
         async move {
             if advertising {
-                let name = adv_config.map(|c| c.local_name);
+                let (name, service_data) = adv_config.map_or_else(
+                    || (None, HashMap::new()),
+                    |c| {
+                        (
+                            Some(c.local_name),
+                            c.service_data.into_iter().collect::<HashMap<_, _>>(),
+                        )
+                    },
+                );
                 let _ = tx.send(CentralEvent::DeviceDiscovered(BleDevice {
                     id: DeviceId::from("mock-peripheral"),
                     name,
                     rssi: Some(-50),
                     services,
                     manufacturer_data: HashMap::new(),
-                    service_data: HashMap::new(),
+                    service_data,
                 }));
             }
             Ok(())
@@ -861,6 +869,7 @@ mod tests {
             .start_advertising(&AdvertisingConfig {
                 local_name: "test".into(),
                 service_uuids: vec![svc_uuid],
+                ..Default::default()
             })
             .await
             .unwrap();
@@ -1163,11 +1172,40 @@ mod tests {
         let config = AdvertisingConfig {
             local_name: "test".into(),
             service_uuids: vec![],
+            ..Default::default()
         };
 
         peripheral.start_advertising(&config).await.unwrap();
         let result = peripheral.start_advertising(&config).await;
         assert!(matches!(result, Err(BlewError::AlreadyAdvertising)));
+    }
+
+    #[tokio::test]
+    async fn advertised_service_data_reaches_the_scanning_central() {
+        let (c, p) = MockLink::pair();
+        let peripheral = Peripheral::from_backend(p.peripheral);
+        let central = Central::from_backend(c.central);
+        let svc = Uuid::from_u128(0x0000_1234_0000_1000_8000_0080_5f9b_34fb);
+
+        peripheral
+            .start_advertising(&AdvertisingConfig {
+                local_name: "test".into(),
+                service_uuids: vec![svc],
+                service_data: [(svc, vec![7, 8, 9])].into_iter().collect(),
+            })
+            .await
+            .unwrap();
+        let mut events = central.events();
+        assert!(matches!(
+            events.next().await.unwrap(),
+            CentralEvent::AdapterStateChanged { powered: true }
+        ));
+        central.start_scan(ScanFilter::default()).await.unwrap();
+
+        let Some(CentralEvent::DeviceDiscovered(device)) = events.next().await else {
+            panic!("the advertisement never reached the central");
+        };
+        assert_eq!(device.service_data.get(&svc), Some(&vec![7, 8, 9]));
     }
 
     #[tokio::test]
@@ -1529,6 +1567,7 @@ mod tests {
         let config = AdvertisingConfig {
             local_name: "test".into(),
             service_uuids: vec![],
+            ..Default::default()
         };
 
         peripheral.start_advertising(&config).await.unwrap();


### PR DESCRIPTION
Part of #16 — the `addServiceData` half of it, not the whole issue.

## Why this and not another service UUID

An advertisement that already carries one 128-bit service UUID has 13 of its
31 bytes left. A second 128-bit UUID needs 18 and does not fit; service data
under a 16-bit UUID needs eight. For anything that has to publish a few bytes
before a connection exists — which side dials first, whether a group is up —
service data is the only room left, once manufacturer data is off the table.

## Where it goes on Android

In the scan response, alongside the name and for the same reason. Service data
keyed by a 128-bit UUID costs 18 bytes of its own, so with a 128-bit service
UUID already in the advertisement the two never fit together and the stack
answers `ADVERTISE_FAILED_DATA_TOO_LARGE`. The scan response has 31 bytes of
its own and is where blew already puts the name.

The cost is that a purely passive scanner never asks for it. Every backend
here scans actively, as do the platform defaults — `CBCentralManager`,
BlueZ `StartDiscovery`, and Android's legacy `ScanSettings`, which offers no
passive mode at all — so this is a caveat rather than a limitation.

Linux needs no such split: BlueZ decides the layout itself from the
`LEAdvertisement1` properties.

## The Apple question

`AdvertisingConfig` documents manufacturer data as deliberately absent, because
CoreBluetooth's `startAdvertising:` honours only `CBAdvertisementDataLocalNameKey`
and `CBAdvertisementDataServiceUUIDsKey`, and a field that one backend silently
ignores is worse than no field. Service data is out of Apple's reach for exactly
the same reason.

This answers it differently, and the difference is deliberate: a non-empty
`service_data` on Apple is `BlewError::NotSupported`, not a silent omission. So
the objection — a field that quietly does nothing on one of three backends —
does not apply; an Apple caller finds out. If you would rather it stayed off the
struct entirely, say so and I will close this; the reasoning is yours and I would
rather match it than argue past it.

What tipped me toward offering it is that the two backends that *can* do it are
the two where an application has no fallback. Apple's local name is a
per-advertisement field, so a small payload can ride there; Android has no
per-advertisement name at all, only `BluetoothAdapter.name` — the phone's own
Bluetooth name, which is a poor place to put anything (see #21).

## What changed

- `AdvertisingConfig::service_data: BTreeMap<Uuid, Vec<u8>>`. Ordered rather
  than hashed so the bytes on the air do not depend on iteration order.
- Android: `AdvertiseData.Builder.addServiceData` on the scan response,
  marshalled as the parallel arrays the JNI boundary already uses for service
  UUIDs.
- Linux: bluer's `Advertisement::service_data`.
- Apple: `NotSupported` when the map is non-empty.
- The mock backend now hands advertised service data to the scanning central.
  It dropped it before, so `BleDevice::service_data` had nothing exercising it;
  the new test fails if the mock goes back to dropping it.
- Examples updated to the `..Default::default()` spread the struct's own docs
  recommend.

`mise run test` (95 passed), `mise run lint`, `mise run fmt:check` and
`mise run ci:compile-kotlin` all pass. Lint reports five pre-existing errors on
`main` unrelated to this branch. Not yet exercised on an Android or Apple
device — the Linux path is the one I can run here.
