### PR TITLE
notify/indicate per call + indication confirmations (fixes #18, #9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,7 +27,10 @@ All notable changes to `blew` are documented here. Format follows
   confirms. `nativeOnNotificationSent`
   was added to the Android JNI bridge to carry the callback into Rust; the
   call is tagged with a monotonic seq so a busy-retry can never resolve a newer
-  call with an older callback.
+  call with an older callback. A per-device Kotlin semaphore serializes sends
+  (Android silently drops concurrent ones); it is released only for a tracked
+  in-flight send, and a Kotlin-side backstop frees it if `onNotificationSent`
+  never arrives, so a silent stack cannot wedge future notifications.
 
 - **Linux indication support.** Characteristics declaring
   `CharacteristicProperties::INDICATE` now register an indication CCCD. Bluer

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,8 +30,12 @@ All notable changes to `blew` are documented here. Format follows
   call with an older callback.
 
 - **Linux indication support.** Characteristics declaring
-  `CharacteristicProperties::INDICATE` now register an indication CCCD, and
-  BlueZ resolves the notifier only after the peer confirms a `NotifyKind::Indicate`.
+  `CharacteristicProperties::INDICATE` now register an indication CCCD. Bluer
+  only wires up a confirmation channel for an Indicate-only characteristic
+  (`INDICATE` without `NOTIFY`), so only there does BlueZ resolve the notifier
+  after the peer confirms an indication; on a characteristic that also
+  declares `NOTIFY`, the central's CCCD pick is delivered without
+  confirmation.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,14 +14,17 @@ All notable changes to `blew` are documented here. Format follows
   Linux derive the wire format from the property the central subscribed
   through (the CCCD) and reject an unsupported kind, and the mock backend
   mirrors them, with **`BlewError::NotifyKindMismatch { char_uuid,
-  requested }`** as the typed error.
+  requested }`** as the typed error. An unknown characteristic id is still a
+  `LocalCharacteristicNotFound`, matching Apple and Android.
 
 - **Android `notify_characteristic` now resolves `NotifyKind::Indicate` only
   once the stack reports the send** via `onNotificationSent` (issue #9). For
   an indication that is after the peer's ATT confirmation — a true
   acknowledgement. A five-second backstop degrades a stack that never reports
-  to "accepted". Apple and Linux already resolve appropriately: CoreBluetooth
-  on queue acceptance and BlueZ after the peer confirms. `NativeOnNotificationSent`
+  to "accepted". A stack that rejects the send outright fails fast with an
+  error instead of looking busy. Apple and Linux already resolve
+  appropriately: CoreBluetooth on queue acceptance and BlueZ after the peer
+  confirms. `nativeOnNotificationSent`
   was added to the Android JNI bridge to carry the callback into Rust; the
   call is tagged with a monotonic seq so a busy-retry can never resolve a newer
   call with an older callback.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,38 @@ All notable changes to `blew` are documented here. Format follows
 
 ## [Unreleased]
 
+### Added
+
+- **`NotifyKind::{Notify, Indicate}` — per-call selection of the ATT write
+  kind in `Peripheral::notify_characteristic`** (issue #18). `NotifyKind::Indicate`
+  sends an ATT Handle Value Indication; `NotifyKind::Notify` (default) a
+  Handle Value Notification. Android honours the selection exactly. Apple and
+  Linux derive the wire format from the property the central subscribed
+  through (the CCCD) and reject an unsupported kind, and the mock backend
+  mirrors them, with **`BlewError::NotifyKindMismatch { char_uuid,
+  requested }`** as the typed error.
+
+- **Android `notify_characteristic` now resolves `NotifyKind::Indicate` only
+  once the stack reports the send** via `onNotificationSent` (issue #9). For
+  an indication that is after the peer's ATT confirmation — a true
+  acknowledgement. A five-second backstop degrades a stack that never reports
+  to "accepted". Apple and Linux already resolve appropriately: CoreBluetooth
+  on queue acceptance and BlueZ after the peer confirms. `NativeOnNotificationSent`
+  was added to the Android JNI bridge to carry the callback into Rust; the
+  call is tagged with a monotonic seq so a busy-retry can never resolve a newer
+  call with an older callback.
+
+- **Linux indication support.** Characteristics declaring
+  `CharacteristicProperties::INDICATE` now register an indication CCCD, and
+  BlueZ resolves the notifier only after the peer confirms a `NotifyKind::Indicate`.
+
+### Changed
+
+- **Breaking: `Peripheral::notify_characteristic` gained a `kind:
+  NotifyKind` argument** before `value` (issue #18). It is a single type
+  parameter — not an options struct — so the compiler points you at every call
+  site. See the upgrade guide below.
+
 ### Fixed
 
 - **Android: `BleCentralManager.init` / `BlePeripheralManager.init` crashed on
@@ -709,6 +741,30 @@ PeripheralRequest::Write { client_id, char_uuid, offset, value, responder, .. } 
 
 `offset` is `0` for ordinary writes, so applications that never receive a
 payload larger than `MTU - 3` can keep treating `value` as the whole value.
+
+---
+
+## Upgrade guide — Unreleased → next
+
+**If you called `Peripheral::notify_characteristic`, pass a `NotifyKind`**:
+
+```rust
+// Before
+peripheral.notify_characteristic(&device_id, char_uuid, value).await?;
+
+// After — a notification (unchanged wire format)
+peripheral
+    .notify_characteristic(&device_id, char_uuid, NotifyKind::Notify, value)
+    .await?;
+
+// After — an indication; on Android the call resolves only once the peer
+// has confirmed at the ATT layer
+peripheral
+    .notify_characteristic(&device_id, char_uuid, NotifyKind::Indicate, value)
+    .await?;
+```
+
+`use blew::peripheral::NotifyKind;` (also re-exported from `blew`).
 
 ---
 

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -86,6 +86,12 @@ object BlePeripheralManager {
         notifySemaphores[addr]?.release()
     }
 
+    // Rust-assigned id for the notify call currently in flight per device.
+    // Stored on accept and echoed back through [nativeOnNotificationSent] so a
+    // busy-retry can never resolve a newer call with an older callback. Safe
+    // as a single slot per device: the semaphore above serializes sends.
+    private val notifySeqByDevice = ConcurrentHashMap<String, Long>()
+
     // ── L2CAP state ──
     private val l2cap =
         L2capSocketManager(
@@ -136,6 +142,18 @@ object BlePeripheralManager {
 
     @JvmStatic
     external fun nativeOnAdapterStateChanged(powered: Boolean)
+
+    /**
+     * Reports that a previously accepted [`notifyCharacteristic`] call reached
+     * the stack's `onNotificationSent` callback. `seq` is the id Rust assigned
+     * when the call was made; `status` is the BluetoothGatt status code.
+     */
+    @JvmStatic
+    external fun nativeOnNotificationSent(
+        deviceAddr: String,
+        seq: Long,
+        status: Int,
+    )
 
     // ── L2CAP JNI hooks ──
 
@@ -243,7 +261,11 @@ object BlePeripheralManager {
                 device: BluetoothDevice,
                 status: Int,
             ) {
-                releaseNotify(device.address)
+                val addr = device.address
+                releaseNotify(addr)
+                notifySeqByDevice.remove(addr)?.let { seq ->
+                    nativeOnNotificationSent(addr, seq, status)
+                }
             }
 
             override fun onCharacteristicReadRequest(
@@ -548,10 +570,16 @@ object BlePeripheralManager {
     }
 
     /**
-     * Send a notification on a characteristic to a single subscribed device.
+     * Send a notification/indication on a characteristic to a single
+     * subscribed device.
+     *
+     * `confirm` selects the ATT write kind: `false` is a Handle Value
+     * Notification, `true` a Handle Value Indication. `seq` is Rust's
+     * monotonically increasing id for this call, echoed back through
+     * [nativeOnNotificationSent] from `onNotificationSent`.
      *
      * Returns:
-     *   0 = success
+     *   0 = accepted (the stack reports completion via onNotificationSent)
      *   1 = busy (semaphore not available — caller should retry after a short delay)
      *   2 = device not connected or not subscribed to this characteristic
      *   3 = characteristic not found
@@ -561,6 +589,8 @@ object BlePeripheralManager {
         deviceAddr: String,
         charUuid: String,
         value: ByteArray,
+        confirm: Boolean,
+        seq: Long,
     ): Int {
         val uuid = UUID.fromString(charUuid)
         val char = characteristics[uuid] ?: return 3
@@ -568,32 +598,37 @@ object BlePeripheralManager {
         val subs = subscriptions[deviceAddr] ?: return 2
         if (uuid !in subs) return 2
         if (!acquireNotify(deviceAddr, timeoutMs = 50)) return 1
-        val sent = sendNotification(device, char, value)
-        if (!sent) {
+        val status = sendNotification(device, char, value, confirm)
+        if (status != BluetoothStatusCodes.SUCCESS) {
             releaseNotify(deviceAddr)
             return 1
         }
+        notifySeqByDevice[deviceAddr] = seq
         return 0
     }
 
     /**
-     * Send a single notification, handling the API 33+ / legacy split.
-     * On API < 33, synchronizes on [char] to prevent concurrent `char.value`
-     * races when multiple devices are notified from different threads.
+     * Send a single notification/indication, handling the API 33+ / legacy
+     * split. Returns `BluetoothStatusCodes.SUCCESS` when the stack accepted
+     * the value. On API < 33, synchronizes on [char] to prevent concurrent
+     * `char.value` races when multiple devices are notified from different
+     * threads.
      */
     private fun sendNotification(
         device: BluetoothDevice,
         char: BluetoothGattCharacteristic,
         value: ByteArray,
-    ): Boolean =
+        confirm: Boolean,
+    ): Int =
         if (Build.VERSION.SDK_INT >= 33) {
-            gattServer?.notifyCharacteristicChanged(device, char, false, value) ==
-                BluetoothStatusCodes.SUCCESS
+            gattServer?.notifyCharacteristicChanged(device, char, confirm, value)
+                ?: BluetoothStatusCodes.ERROR
         } else {
             @Suppress("DEPRECATION")
             synchronized(char) {
                 char.value = value
-                gattServer?.notifyCharacteristicChanged(device, char, false) ?: false
+                val sent = gattServer?.notifyCharacteristicChanged(device, char, confirm) ?: false
+                if (sent) BluetoothStatusCodes.SUCCESS else BluetoothStatusCodes.ERROR
             }
         }
 

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -583,6 +583,7 @@ object BlePeripheralManager {
      *   1 = busy (semaphore not available — caller should retry after a short delay)
      *   2 = device not connected or not subscribed to this characteristic
      *   3 = characteristic not found
+     *   4 = stack rejected the send (do not retry)
      */
     @JvmStatic
     fun notifyCharacteristic(
@@ -601,7 +602,7 @@ object BlePeripheralManager {
         val status = sendNotification(device, char, value, confirm)
         if (status != BluetoothStatusCodes.SUCCESS) {
             releaseNotify(deviceAddr)
-            return 1
+            return 4
         }
         notifySeqByDevice[deviceAddr] = seq
         return 0

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -16,6 +16,7 @@ import android.util.Log
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import java.util.UUID
 import java.util.concurrent.ConcurrentHashMap
@@ -51,6 +52,12 @@ object BlePeripheralManager {
      */
     private val scope = CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
+    // How long to wait for `onNotificationSent` before freeing the notify
+    // semaphore ourselves. Slightly longer than Rust's NOTIFY_ACK_TIMEOUT
+    // (5s), so Rust's own timeout resolves its waiter first and the backstop
+    // only frees the Kotlin-side semaphore that Rust cannot see.
+    private const val NOTIFY_BACKSTOP_MS = 6_000L
+
     private var gattServer: BluetoothGattServer? = null
     private var advertiser: BluetoothLeAdvertiser? = null
 
@@ -84,6 +91,44 @@ object BlePeripheralManager {
 
     private fun releaseNotify(addr: String) {
         notifySemaphores[addr]?.release()
+    }
+
+    /**
+     * Resolve the in-flight notification for [addr], if one is tracked.
+     * Consuming the tracked seq via `remove` makes this idempotent, so a
+     * stale/duplicate `onNotificationSent` or the backstop can never release
+     * the semaphore twice (over-release would let Android silently drop
+     * concurrent sends). Forwards the outcome to Rust.
+     *
+     * [delayMs] the backstop's artificial delay used purely for logging.
+     */
+    private fun completeNotify(
+        addr: String,
+        status: Int,
+        delayMs: Long = 0,
+    ) {
+        notifySeqByDevice.remove(addr)?.let { seq ->
+            releaseNotify(addr)
+            if (delayMs > 0) {
+                Log.w(TAG, "onNotificationSent did not arrive within ${delayMs}ms; releasing notify semaphore")
+            }
+            nativeOnNotificationSent(addr, seq, status)
+        }
+    }
+
+    /**
+     * Safety net for stacks that never fire `onNotificationSent`. The Rust
+     * future times out on its own, but the Kotlin per-device semaphore would
+     * otherwise stay acquired forever, stalling every later send for this
+     * device. After [NOTIFY_BACKSTOP_MS] this consumes the tracked seq and
+     * frees the semaphore. `completeNotify` is idempotent, so if the real
+     * callback already arrived this is a no-op.
+     */
+    private fun scheduleNotifyBackstop(addr: String) {
+        scope.launch {
+            delay(NOTIFY_BACKSTOP_MS)
+            completeNotify(addr, BluetoothStatusCodes.ERROR_UNKNOWN, NOTIFY_BACKSTOP_MS)
+        }
     }
 
     // Rust-assigned id for the notify call currently in flight per device.
@@ -262,10 +307,12 @@ object BlePeripheralManager {
                 status: Int,
             ) {
                 val addr = device.address
-                releaseNotify(addr)
-                notifySeqByDevice.remove(addr)?.let { seq ->
-                    nativeOnNotificationSent(addr, seq, status)
-                }
+                // Only release the per-device semaphore when this callback is for a
+                // send we actually accepted and which hasn't already been resolved
+                // (by a prior callback or the backstop). Removing the tracked seq
+                // atomically both consumes it and gates the release, so a stale or
+                // duplicate callback can never over-release.
+                completeNotify(addr, status)
             }
 
             override fun onCharacteristicReadRequest(
@@ -605,6 +652,7 @@ object BlePeripheralManager {
             return 4
         }
         notifySeqByDevice[deviceAddr] = seq
+        scheduleNotifyBackstop(deviceAddr)
         return 0
     }
 

--- a/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
+++ b/crates/blew/android/src/main/java/org/jakebot/blew/BlePeripheralManager.kt
@@ -623,13 +623,13 @@ object BlePeripheralManager {
     ): Int =
         if (Build.VERSION.SDK_INT >= 33) {
             gattServer?.notifyCharacteristicChanged(device, char, confirm, value)
-                ?: BluetoothStatusCodes.ERROR
+                ?: BluetoothStatusCodes.ERROR_UNKNOWN
         } else {
             @Suppress("DEPRECATION")
             synchronized(char) {
                 char.value = value
                 val sent = gattServer?.notifyCharacteristicChanged(device, char, confirm) ?: false
-                if (sent) BluetoothStatusCodes.SUCCESS else BluetoothStatusCodes.ERROR
+                if (sent) BluetoothStatusCodes.SUCCESS else BluetoothStatusCodes.ERROR_UNKNOWN
             }
         }
 

--- a/crates/blew/examples/integration_peripheral.rs
+++ b/crates/blew/examples/integration_peripheral.rs
@@ -250,7 +250,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                         }
                         println!("  echo: {} bytes from {client_id}", value.len());
                         if let Err(e) = peripheral
-                            .notify_characteristic(&client_id, ECHO_CHAR_UUID, value)
+                            .notify_characteristic(
+                                &client_id,
+                                ECHO_CHAR_UUID,
+                                blew::peripheral::NotifyKind::Notify,
+                                value,
+                            )
                             .await
                         {
                             eprintln!("  notify failed: {e}");

--- a/crates/blew/src/error.rs
+++ b/crates/blew/src/error.rs
@@ -1,3 +1,4 @@
+use crate::peripheral::types::NotifyKind;
 use crate::types::DeviceId;
 use std::error::Error;
 use uuid::Uuid;
@@ -39,6 +40,14 @@ pub enum BlewError {
 
     #[error("local characteristic {char_uuid} not found")]
     LocalCharacteristicNotFound { char_uuid: Uuid },
+
+    #[error(
+        "local characteristic {char_uuid} does not declare a property supporting {requested:?} value updates"
+    )]
+    NotifyKindMismatch {
+        char_uuid: Uuid,
+        requested: NotifyKind,
+    },
 
     #[error("already advertising")]
     AlreadyAdvertising,

--- a/crates/blew/src/peripheral/backend.rs
+++ b/crates/blew/src/peripheral/backend.rs
@@ -1,4 +1,4 @@
-use super::types::{AdvertisingConfig, PeripheralRequest, PeripheralStateEvent};
+use super::types::{AdvertisingConfig, NotifyKind, PeripheralRequest, PeripheralStateEvent};
 use crate::error::BlewResult;
 use crate::gatt::service::GattService;
 use crate::l2cap::{L2capChannel, types::Psm};
@@ -45,6 +45,15 @@ pub trait PeripheralBackend: private::Sealed + Send + Sync + 'static {
 
     /// Push a characteristic value update to a single subscribed central.
     ///
+    /// `kind` selects the ATT write mechanism per call. On Android it is
+    /// honoured exactly: `NotifyKind::Indicate` is sent as an indication and
+    /// the future resolves once the stack reports the send (i.e. after the
+    /// peer's ATT confirmation). Apple and Linux derive the wire format from
+    /// the property the central subscribed through (the CCCD), so on those
+    /// platforms `kind` is validated against the characteristic's declared
+    /// properties and an unsupported request fails with
+    /// [`BlewError::NotifyKindMismatch`](crate::error::BlewError::NotifyKindMismatch).
+    ///
     /// The notification is unicast to the central identified by `device_id`
     /// when the platform's GATT server API supports per-subscriber targeting
     /// (Apple, Android). On Linux/BlueZ, BlueZ's `CharacteristicNotifier`
@@ -54,6 +63,7 @@ pub trait PeripheralBackend: private::Sealed + Send + Sync + 'static {
         &self,
         device_id: &DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> impl Future<Output = BlewResult<()>> + Send;
 

--- a/crates/blew/src/peripheral/mod.rs
+++ b/crates/blew/src/peripheral/mod.rs
@@ -2,8 +2,8 @@ pub mod backend;
 pub mod types;
 
 pub use types::{
-    AdvertisingConfig, PeripheralConfig, PeripheralRequest, PeripheralStateEvent, ReadResponder,
-    WriteResponder,
+    AdvertisingConfig, NotifyKind, PeripheralConfig, PeripheralRequest, PeripheralStateEvent,
+    ReadResponder, WriteResponder,
 };
 
 use crate::error::{BlewError, BlewResult};
@@ -84,16 +84,18 @@ impl<B: PeripheralBackend> Peripheral<B> {
 
     /// Push a characteristic value update to a single subscribed central.
     ///
-    /// See [`PeripheralBackend::notify_characteristic`] for the per-device
-    /// semantics and the Linux-only broadcast fallback.
+    /// `kind` selects the ATT write mechanism per call. See
+    /// [`NotifyKind`] for the per-platform completion semantics and the
+    /// [`PeripheralBackend::notify_characteristic`] per-device routing.
     pub async fn notify_characteristic(
         &self,
         device_id: &DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> BlewResult<()> {
         self.backend
-            .notify_characteristic(device_id, char_uuid, value)
+            .notify_characteristic(device_id, char_uuid, kind, value)
             .await
     }
 

--- a/crates/blew/src/peripheral/types.rs
+++ b/crates/blew/src/peripheral/types.rs
@@ -3,6 +3,45 @@ use crate::types::DeviceId;
 use tokio::sync::oneshot;
 use uuid::Uuid;
 
+/// How a characteristic value update is delivered to a subscribed central.
+///
+/// Mirrors the ATT distinction between a Handle Value Notification and a
+/// Handle Value Indication. An indication is answered by the peer's ATT layer
+/// with a confirmation — the only signal a peripheral gets that the value was
+/// actually received — which is why [`Self::Indicate`] is the right choice for
+/// delivery-critical data.
+///
+/// # Completion semantics
+///
+/// [`PeripheralBackend::notify_characteristic`] resolves at a different point
+/// on each platform:
+///
+/// - **Android**: when the stack's `onNotificationSent` reports the send. For
+///   indications that is after the peer's ATT confirmation — a true
+///   acknowledgement.
+/// - **Apple**: when CoreBluetooth accepts the value into its transmit queue.
+///   CoreBluetooth exposes no per-indication acknowledgement.
+/// - **Linux/BlueZ**: when every live notifier's `notify()` returns. BlueZ
+///   resolves an indication only after the peer confirms.
+/// - **Mock**: immediately.
+///
+/// # Per-call vs per-subscription
+///
+/// The kind is selected **per call**. Apple and Linux ignore it for the wire
+/// format: CoreBluetooth and BlueZ derive notification-vs-indication from the
+/// property the central subscribed through (the CCCD value). On those
+/// platforms, requesting a kind the characteristic does not declare yields
+/// [`BlewError::NotifyKindMismatch`](crate::error::BlewError::NotifyKindMismatch)
+/// instead of silently sending the wrong wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum NotifyKind {
+    /// ATT Handle Value Notification: fire-and-forget, no confirmation.
+    #[default]
+    Notify,
+    /// ATT Handle Value Indication: the peer answers with a confirmation.
+    Indicate,
+}
+
 /// Configuration for initialising the peripheral role.
 ///
 /// Construct with `..Default::default()` so a new field costs you one

--- a/crates/blew/src/peripheral/types.rs
+++ b/crates/blew/src/peripheral/types.rs
@@ -22,7 +22,11 @@ use uuid::Uuid;
 /// - **Apple**: when CoreBluetooth accepts the value into its transmit queue.
 ///   CoreBluetooth exposes no per-indication acknowledgement.
 /// - **Linux/BlueZ**: when every live notifier's `notify()` returns. BlueZ
-///   resolves an indication only after the peer confirms.
+///   confirms an indication only after the peer's ATT acknowledgement, but
+///   bluer only wires up the confirmation channel for an *Indicate-only*
+///   characteristic (`INDICATE` without `NOTIFY`). On a characteristic that
+///   also declares `NOTIFY`, the central's CCCD pick is delivered without a
+///   confirmation.
 /// - **Mock**: immediately.
 ///
 /// # Per-call vs per-subscription

--- a/crates/blew/src/platform/android/jni_hooks.rs
+++ b/crates/blew/src/platform/android/jni_hooks.rs
@@ -28,13 +28,14 @@
 use std::panic::{AssertUnwindSafe, catch_unwind};
 
 use jni::objects::{JByteArray, JClass, JString};
-use jni::sys::{JNI_TRUE, jboolean, jint};
+use jni::sys::{JNI_TRUE, jboolean, jint, jlong};
 use jni::{EnvUnowned, jni_sig, jni_str};
 use tokio::sync::oneshot;
-use tracing::trace;
+use tracing::{debug, trace};
 use uuid::Uuid;
 
 use crate::central::types::{CentralEvent, DisconnectCause};
+use crate::error::BlewError;
 use crate::l2cap::types::Psm;
 use crate::peripheral::types::{
     PeripheralRequest, PeripheralStateEvent, ReadResponder, WriteResponder,
@@ -301,6 +302,34 @@ pub unsafe extern "C" fn Java_org_jakebot_blew_BlePeripheralManager_nativeOnAdap
         super::peripheral::send_state_event(PeripheralStateEvent::AdapterStateChanged {
             powered: powered == JNI_TRUE,
         });
+    });
+}
+
+#[unsafe(no_mangle)]
+pub unsafe extern "C" fn Java_org_jakebot_blew_BlePeripheralManager_nativeOnNotificationSent(
+    mut env: EnvUnowned,
+    _class: JClass,
+    device_addr: JString,
+    seq: jlong,
+    status: jint,
+) {
+    guard("nativeOnNotificationSent", || {
+        env.with_env(|env| {
+            let Some(addr) = jstring_to_string(env, &device_addr) else {
+                return Ok::<_, jni::errors::Error>(());
+            };
+            debug!(addr, seq, status, "notification ack from Kotlin");
+            let result = if status == 0 {
+                Ok(())
+            } else {
+                Err(BlewError::Peripheral {
+                    source: format!("notification send failed (status {status})").into(),
+                })
+            };
+            super::peripheral::complete_pending_notify(&addr, seq, result);
+            Ok(())
+        })
+        .into_outcome();
     });
 }
 

--- a/crates/blew/src/platform/android/peripheral.rs
+++ b/crates/blew/src/platform/android/peripheral.rs
@@ -519,6 +519,13 @@ impl PeripheralBackend for AndroidPeripheral {
                     remove_pending_notify(&device_addr, seq);
                     return Ok(());
                 }
+                // 4 = the stack rejected the send; retrying cannot help.
+                4 => {
+                    remove_pending_notify(&device_addr, seq);
+                    return Err(BlewError::Peripheral {
+                        source: "notification rejected by the stack".into(),
+                    });
+                }
                 1 => {
                     // Busy -- previous notification still in flight for this
                     // device, so this one was never accepted and no callback

--- a/crates/blew/src/platform/android/peripheral.rs
+++ b/crates/blew/src/platform/android/peripheral.rs
@@ -489,7 +489,7 @@ impl PeripheralBackend for AndroidPeripheral {
             // would be dropped (we then stall until NOTIFY_ACK_TIMEOUT).
             set_pending_notify(&device_addr, seq, ack_tx);
 
-            let status: i32 = jvm()
+            let status: i32 = match jvm()
                 .attach_current_thread(|env| {
                     let addr_str = env.new_string(&device_addr)?;
                     let uuid_str = env.new_string(char_uuid.to_string())?;
@@ -509,7 +509,16 @@ impl PeripheralBackend for AndroidPeripheral {
                     )?;
                     ret.i()
                 })
-                .map_err(|e| jni_err(&e))?;
+                .map_err(|e| jni_err(&e))
+            {
+                Ok(status) => status,
+                // JNI failure: the call was never accepted, so no callback
+                // will arrive. Drop the waiter so the map can't leak.
+                Err(e) => {
+                    remove_pending_notify(&device_addr, seq);
+                    return Err(e);
+                }
+            };
 
             match status {
                 // 0 = accepted; resolve once onNotificationSent reports.

--- a/crates/blew/src/platform/android/peripheral.rs
+++ b/crates/blew/src/platform/android/peripheral.rs
@@ -1,3 +1,6 @@
+use std::collections::HashMap;
+use std::sync::atomic::{AtomicI64, Ordering};
+
 use jni::objects::{JObject, JObjectArray};
 use jni::{jni_sig, jni_str};
 use parking_lot::Mutex;
@@ -12,7 +15,7 @@ use crate::gatt::service::GattService;
 use crate::l2cap::{L2capChannel, types::Psm};
 use crate::peripheral::backend::{self, PeripheralBackend};
 use crate::peripheral::types::{
-    AdvertisingConfig, PeripheralConfig, PeripheralRequest, PeripheralStateEvent,
+    AdvertisingConfig, NotifyKind, PeripheralConfig, PeripheralRequest, PeripheralStateEvent,
 };
 use crate::types::DeviceId;
 use crate::util::BroadcastEventStream;
@@ -31,11 +34,27 @@ const ADVERTISE_OK: i32 = 0;
 /// independently of the Rust slot, so this can still come back.
 const ADVERTISE_ALREADY: i32 = 2;
 
+/// How long `notify_characteristic` waits for Kotlin's `onNotificationSent`
+/// before degrading to "accepted, treated as sent". The stack normally reports
+/// well within a second; this only bounds a callback that never arrives.
+const NOTIFY_ACK_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5);
+
+/// Monotonic id tagging each notify request so a busy-retry can never resolve
+/// a newer call with an older call's `onNotificationSent` callback. Rust
+/// assigns it and echoes it back through the JNI call; Kotlin stores the value
+/// on accept and returns it from the callback.
+static NEXT_NOTIFY_SEQ: AtomicI64 = AtomicI64::new(0);
+
 struct PeripheralState {
     request_tx: mpsc::UnboundedSender<PeripheralRequest>,
     request_rx: Mutex<Option<mpsc::UnboundedReceiver<PeripheralRequest>>>,
     state_tx: broadcast::Sender<PeripheralStateEvent>,
     advertise: Mutex<AdvertiseState>,
+    /// Notification sends awaiting Kotlin's `onNotificationSent`, keyed by
+    /// (device address, notify seq). Completed (and removed) by
+    /// `nativeOnNotificationSent`; timed out and removed if the stack never
+    /// reports.
+    pending_notifies: Mutex<HashMap<(String, i64), oneshot::Sender<BlewResult<()>>>>,
 }
 
 /// Run `f` against the advertising state, if the backend is initialised.
@@ -163,6 +182,62 @@ pub(crate) fn send_state_event(event: PeripheralStateEvent) {
     }
 }
 
+fn set_pending_notify(addr: &str, seq: i64, tx: oneshot::Sender<BlewResult<()>>) {
+    if let Some(s) = STATE.lock().as_ref() {
+        s.pending_notifies
+            .lock()
+            .insert((addr.to_string(), seq), tx);
+    }
+}
+
+fn remove_pending_notify(addr: &str, seq: i64) {
+    if let Some(s) = STATE.lock().as_ref() {
+        s.pending_notifies.lock().remove(&(addr.to_string(), seq));
+    }
+}
+
+/// Resolve the waiter for one accepted notification from Kotlin's
+/// `onNotificationSent`. Unknown (stale, or already timed out) seq values are
+/// ignored.
+pub(crate) fn complete_pending_notify(addr: &str, seq: i64, result: BlewResult<()>) {
+    if let Some(s) = STATE.lock().as_ref() {
+        let tx = s.pending_notifies.lock().remove(&(addr.to_string(), seq));
+        if let Some(tx) = tx {
+            let _ = tx.send(result);
+        }
+    }
+}
+
+/// Wait for the stack's `onNotificationSent` after it has accepted a value.
+/// A missing callback is degraded to success — matching the "accepted into the
+/// transmit queue" completion Apple offers — rather than surfacing a spurious
+/// failure the caller cannot act on.
+async fn await_notify_ack(
+    device_addr: String,
+    seq: i64,
+    rx: oneshot::Receiver<BlewResult<()>>,
+) -> BlewResult<()> {
+    match tokio::time::timeout(NOTIFY_ACK_TIMEOUT, rx).await {
+        Ok(Ok(result)) => {
+            remove_pending_notify(&device_addr, seq);
+            result
+        }
+        Ok(Err(_)) => {
+            // Sender dropped without reporting (backend shut down).
+            remove_pending_notify(&device_addr, seq);
+            Ok(())
+        }
+        Err(_) => {
+            warn!(
+                device_addr,
+                seq, "notification ack timed out; treating as sent"
+            );
+            remove_pending_notify(&device_addr, seq);
+            Ok(())
+        }
+    }
+}
+
 pub struct AndroidPeripheral;
 
 impl AndroidPeripheral {
@@ -264,6 +339,7 @@ impl PeripheralBackend for AndroidPeripheral {
             request_rx: Mutex::new(Some(request_rx)),
             state_tx,
             advertise: Mutex::new(AdvertiseState::default()),
+            pending_notifies: Mutex::new(HashMap::new()),
         });
         // The L2CAP statics are shared between the two roles but were only
         // initialised from the central path. A peripheral-only app would find
@@ -393,13 +469,26 @@ impl PeripheralBackend for AndroidPeripheral {
         &self,
         device_id: &DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> BlewResult<()> {
         let device_addr = device_id.as_str().to_owned();
+        let confirm = kind == NotifyKind::Indicate;
+        let seq = NEXT_NOTIFY_SEQ.fetch_add(1, Ordering::Relaxed);
+
         // Retry loop: Kotlin returns 1 ("busy") when the previous
         // notification hasn't completed yet (onNotificationSent pending).
-        // We retry with async sleep so we don't block the tokio thread.
+        // We retry with async sleep so we don't block the tokio thread. The
+        // seq stays fixed across retries, so once accepted, the callback that
+        // resolves us is unambiguously ours even if another device's (or a
+        // stale) callback races.
         for attempt in 0..50_u32 {
+            let (ack_tx, ack_rx) = oneshot::channel();
+            // Register before the JNI call: `onNotificationSent` can fire at
+            // any moment after the stack accepts, and an unregistered waiter
+            // would be dropped (we then stall until NOTIFY_ACK_TIMEOUT).
+            set_pending_notify(&device_addr, seq, ack_tx);
+
             let status: i32 = jvm()
                 .attach_current_thread(|env| {
                     let addr_str = env.new_string(&device_addr)?;
@@ -409,27 +498,42 @@ impl PeripheralBackend for AndroidPeripheral {
                     let ret = env.call_static_method(
                         peripheral_class(),
                         jni_str!("notifyCharacteristic"),
-                        jni_sig!("(Ljava/lang/String;Ljava/lang/String;[B)I"),
-                        &[(&addr_str).into(), (&uuid_str).into(), (&j_value).into()],
+                        jni_sig!("(Ljava/lang/String;Ljava/lang/String;[BZJ)I"),
+                        &[
+                            (&addr_str).into(),
+                            (&uuid_str).into(),
+                            (&j_value).into(),
+                            confirm.into(),
+                            seq.into(),
+                        ],
                     )?;
                     ret.i()
                 })
                 .map_err(|e| jni_err(&e))?;
 
             match status {
-                // 0 = success; 2 = no subscribers (not an error).
-                0 | 2 => return Ok(()),
+                // 0 = accepted; resolve once onNotificationSent reports.
+                0 => return await_notify_ack(device_addr, seq, ack_rx).await,
+                // 2 = no subscribers (not an error).
+                2 => {
+                    remove_pending_notify(&device_addr, seq);
+                    return Ok(());
+                }
                 1 => {
-                    // Busy -- previous notification still in flight.
-                    // Yield to tokio and retry after a short delay.
+                    // Busy -- previous notification still in flight for this
+                    // device, so this one was never accepted and no callback
+                    // will arrive. Yield to tokio and retry after a short delay.
+                    remove_pending_notify(&device_addr, seq);
                     if attempt < 49 {
                         tokio::time::sleep(std::time::Duration::from_millis(5)).await;
                     }
                 }
                 3 => {
+                    remove_pending_notify(&device_addr, seq);
                     return Err(BlewError::LocalCharacteristicNotFound { char_uuid });
                 }
                 other => {
+                    remove_pending_notify(&device_addr, seq);
                     return Err(BlewError::Peripheral {
                         source: format!("notify returned unknown status {other}").into(),
                     });

--- a/crates/blew/src/platform/apple/peripheral.rs
+++ b/crates/blew/src/platform/apple/peripheral.rs
@@ -50,8 +50,8 @@ use crate::gatt::service::GattService;
 use crate::l2cap::{L2capChannel, types::Psm};
 use crate::peripheral::backend::{self, PeripheralBackend};
 use crate::peripheral::types::{
-    AdvertisingConfig, PeripheralConfig, PeripheralRequest, PeripheralStateEvent, ReadResponder,
-    WriteResponder,
+    AdvertisingConfig, NotifyKind, PeripheralConfig, PeripheralRequest, PeripheralStateEvent,
+    ReadResponder, WriteResponder,
 };
 use crate::platform::apple::helpers::{
     ObjcSend, cbuuid_to_uuid, central_device_id, retain_send, uuid_to_cbuuid,
@@ -269,6 +269,13 @@ impl PeripheralInner {
 
     fn emit_request(&self, request: PeripheralRequest) {
         let _ = self.request_tx.send(request);
+    }
+
+    /// The declared `CBCharacteristicProperties` of a local characteristic, if
+    /// it is registered.
+    fn char_properties(&self, char_uuid: Uuid) -> Option<CBCharacteristicProperties> {
+        let lock = self.chars.lock();
+        lock.get(&char_uuid).map(|c| unsafe { c.0.properties() })
     }
 }
 
@@ -912,12 +919,34 @@ impl PeripheralBackend for ApplePeripheral {
         &self,
         device_id: &DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> impl Future<Output = BlewResult<()>> + Send {
         let handle = Arc::clone(&self.0);
         let device_id = device_id.clone();
         async move {
-            trace!(device = %device_id, %char_uuid, len = value.len(), "notifying characteristic");
+            // CoreBluetooth has no per-call notification-kind control: the ATT
+            // layer decides between notification and indication from the
+            // property the central subscribed through (the CCCD). Validate the
+            // requested kind against the declared properties so an `Indicate`
+            // on a Notify-only characteristic is a typed error here rather than
+            // a silent wire-format mismatch.
+            let required = match kind {
+                NotifyKind::Notify => CBCharacteristicProperties::Notify,
+                NotifyKind::Indicate => CBCharacteristicProperties::Indicate,
+            };
+            let props = match handle.inner.char_properties(char_uuid) {
+                Some(props) => props,
+                None => return Err(BlewError::LocalCharacteristicNotFound { char_uuid }),
+            };
+            if !props.contains(required) {
+                return Err(BlewError::NotifyKindMismatch {
+                    char_uuid,
+                    requested: kind,
+                });
+            }
+
+            trace!(device = %device_id, %char_uuid, ?kind, len = value.len(), "notifying characteristic");
             // Attempt and enqueue under one lock so a readiness callback cannot
             // slip between them and leave this notification stranded.
             let rx = {

--- a/crates/blew/src/platform/apple/peripheral.rs
+++ b/crates/blew/src/platform/apple/peripheral.rs
@@ -935,9 +935,8 @@ impl PeripheralBackend for ApplePeripheral {
                 NotifyKind::Notify => CBCharacteristicProperties::Notify,
                 NotifyKind::Indicate => CBCharacteristicProperties::Indicate,
             };
-            let props = match handle.inner.char_properties(char_uuid) {
-                Some(props) => props,
-                None => return Err(BlewError::LocalCharacteristicNotFound { char_uuid }),
+            let Some(props) = handle.inner.char_properties(char_uuid) else {
+                return Err(BlewError::LocalCharacteristicNotFound { char_uuid });
             };
             if !props.contains(required) {
                 return Err(BlewError::NotifyKindMismatch {

--- a/crates/blew/src/platform/linux/peripheral.rs
+++ b/crates/blew/src/platform/linux/peripheral.rs
@@ -4,8 +4,8 @@ use crate::gatt::service::GattService;
 use crate::l2cap::{L2capChannel, types::Psm};
 use crate::peripheral::backend::{self, PeripheralBackend};
 use crate::peripheral::types::{
-    AdvertisingConfig, PeripheralConfig, PeripheralRequest, PeripheralStateEvent, ReadResponder,
-    WriteResponder,
+    AdvertisingConfig, NotifyKind, PeripheralConfig, PeripheralRequest, PeripheralStateEvent,
+    ReadResponder, WriteResponder,
 };
 use crate::platform::linux::l2cap::bridge_l2cap;
 use crate::types::DeviceId;
@@ -39,6 +39,9 @@ struct PeripheralInner {
     adv_handle: Mutex<Option<bluer::adv::AdvertisementHandle>>,
     app_handle: Mutex<Option<ApplicationHandle>>,
     notifiers: Mutex<HashMap<Uuid, Vec<SharedNotifier>>>,
+    /// Declared `CharacteristicProperties` per characteristic, so
+    /// `notify_characteristic` can validate the requested `NotifyKind`.
+    char_props: Mutex<HashMap<Uuid, CharacteristicProperties>>,
     request_tx: mpsc::UnboundedSender<PeripheralRequest>,
     request_rx: Mutex<Option<mpsc::UnboundedReceiver<PeripheralRequest>>>,
     state_tx: broadcast::Sender<PeripheralStateEvent>,
@@ -142,6 +145,7 @@ fn build_characteristic(
 ) -> Characteristic {
     let uuid = ch.uuid;
     let props = ch.properties;
+    inner.char_props.lock().insert(uuid, props);
 
     let read = if props.contains(CharacteristicProperties::READ) {
         // Static value -- auto-respond without round-tripping through the event
@@ -241,10 +245,17 @@ fn build_characteristic(
         None
     };
 
-    let notify = if props.contains(CharacteristicProperties::NOTIFY) {
+    let notify = if props
+        .intersects(CharacteristicProperties::NOTIFY | CharacteristicProperties::INDICATE)
+    {
         let inner_n = Arc::clone(inner);
         Some(CharacteristicNotify {
-            notify: true,
+            // BlueZ derives notification-vs-indication from the CCCD the
+            // central wrote. Declare both properties so a central can pick
+            // either; bluer only creates the confirmation channel when
+            // `indicate && !notify` (an Indicate-only characteristic).
+            notify: props.contains(CharacteristicProperties::NOTIFY),
+            indicate: props.contains(CharacteristicProperties::INDICATE),
             method: CharacteristicNotifyMethod::Fun(Box::new(
                 move |notifier: CharacteristicNotifier| {
                     let inner_n = Arc::clone(&inner_n);
@@ -332,6 +343,7 @@ impl PeripheralBackend for LinuxPeripheral {
             adv_handle: Mutex::new(None),
             app_handle: Mutex::new(None),
             notifiers: Mutex::new(HashMap::new()),
+            char_props: Mutex::new(HashMap::new()),
             request_tx,
             request_rx: Mutex::new(Some(request_rx)),
             state_tx,
@@ -461,15 +473,40 @@ impl PeripheralBackend for LinuxPeripheral {
         &self,
         _device_id: &crate::types::DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> impl Future<Output = BlewResult<()>> + Send {
         // NOTE: BlueZ's `CharacteristicNotifier` callback does not expose the
         // remote device identity, so we cannot route a notification to a
         // specific subscriber here. Every live notifier for the characteristic
         // receives the value. See the trait doc for details.
+        //
+        // BlueZ also has no per-call kind control: the CCCD the central wrote
+        // decides between notification and indication, and bluer only creates
+        // a confirmation channel for an Indicate-only characteristic. Validate
+        // the requested kind against the declared properties so an
+        // unsupported request is a typed error rather than a silent
+        // wire-format mismatch.
         let handle = Arc::clone(&self.0);
         async move {
-            trace!(%char_uuid, len = value.len(), "notifying characteristic");
+            let declared = handle
+                .char_props
+                .lock()
+                .get(&char_uuid)
+                .copied()
+                .unwrap_or_default();
+            let supported = match kind {
+                NotifyKind::Notify => declared.contains(CharacteristicProperties::NOTIFY),
+                NotifyKind::Indicate => declared.contains(CharacteristicProperties::INDICATE),
+            };
+            if !supported {
+                return Err(BlewError::NotifyKindMismatch {
+                    char_uuid,
+                    requested: kind,
+                });
+            }
+
+            trace!(%char_uuid, ?kind, len = value.len(), "notifying characteristic");
             // Collect live notifiers without holding the outer Mutex across awaits.
             let arcs: Vec<SharedNotifier> = handle
                 .notifiers

--- a/crates/blew/src/platform/linux/peripheral.rs
+++ b/crates/blew/src/platform/linux/peripheral.rs
@@ -251,9 +251,11 @@ fn build_characteristic(
         let inner_n = Arc::clone(inner);
         Some(CharacteristicNotify {
             // BlueZ derives notification-vs-indication from the CCCD the
-            // central wrote. Declare both properties so a central can pick
-            // either; bluer only creates the confirmation channel when
-            // `indicate && !notify` (an Indicate-only characteristic).
+            // central wrote, so declaring both properties lets a central pick
+            // either wire format. That is separate from the confirmation
+            // channel, which bluer only creates for an Indicate-only
+            // characteristic (`indicate && !notify`): only then does the
+            // peer's confirmation gate `notify()`.
             notify: props.contains(CharacteristicProperties::NOTIFY),
             indicate: props.contains(CharacteristicProperties::INDICATE),
             method: CharacteristicNotifyMethod::Fun(Box::new(

--- a/crates/blew/src/platform/linux/peripheral.rs
+++ b/crates/blew/src/platform/linux/peripheral.rs
@@ -465,6 +465,7 @@ impl PeripheralBackend for LinuxPeripheral {
             handle.adv_handle.lock().take();
             handle.app_handle.lock().take();
             handle.notifiers.lock().clear();
+            handle.char_props.lock().clear();
             Ok(())
         }
     }
@@ -489,12 +490,9 @@ impl PeripheralBackend for LinuxPeripheral {
         // wire-format mismatch.
         let handle = Arc::clone(&self.0);
         async move {
-            let declared = handle
-                .char_props
-                .lock()
-                .get(&char_uuid)
-                .copied()
-                .unwrap_or_default();
+            let Some(declared) = handle.char_props.lock().get(&char_uuid).copied() else {
+                return Err(BlewError::LocalCharacteristicNotFound { char_uuid });
+            };
             let supported = match kind {
                 NotifyKind::Notify => declared.contains(CharacteristicProperties::NOTIFY),
                 NotifyKind::Indicate => declared.contains(CharacteristicProperties::INDICATE),

--- a/crates/blew/src/testing.rs
+++ b/crates/blew/src/testing.rs
@@ -25,11 +25,13 @@ use uuid::Uuid;
 use crate::central::backend::{self, CentralBackend};
 use crate::central::types::{CentralEvent, DisconnectCause, ScanFilter, WriteType};
 use crate::error::{BlewError, BlewResult};
+use crate::gatt::props::CharacteristicProperties;
 use crate::gatt::service::GattService;
 use crate::l2cap::{L2capChannel, types::Psm};
 use crate::peripheral::backend::{self as periph_backend, PeripheralBackend};
 use crate::peripheral::types::{
-    AdvertisingConfig, PeripheralRequest, PeripheralStateEvent, ReadResponder, WriteResponder,
+    AdvertisingConfig, NotifyKind, PeripheralRequest, PeripheralStateEvent, ReadResponder,
+    WriteResponder,
 };
 use crate::types::{BleDevice, DeviceId};
 use crate::util::BroadcastEventStream;
@@ -721,15 +723,44 @@ impl PeripheralBackend for MockPeripheral {
         &self,
         _device_id: &crate::types::DeviceId,
         char_uuid: Uuid,
+        kind: NotifyKind,
         value: Vec<u8>,
     ) -> impl Future<Output = BlewResult<()>> + Send {
         let mut link = self.link.lock();
-        if std::mem::take(&mut link.drop_next_notification) {
-            // Silently discard the notification, as if it were lost in transit.
-        } else if let Some(tx) = link.subscriptions.get(&char_uuid) {
-            let _ = tx.send(Bytes::from(value));
+        // Mirror the real backends: an unsupported kind is a typed error, not
+        // a silent wire-format mismatch.
+        let supported = link.services.iter().any(|svc| {
+            svc.characteristics.iter().any(|ch| {
+                ch.uuid == char_uuid
+                    && match kind {
+                        NotifyKind::Notify => {
+                            ch.properties.contains(CharacteristicProperties::NOTIFY)
+                        }
+                        NotifyKind::Indicate => {
+                            ch.properties.contains(CharacteristicProperties::INDICATE)
+                        }
+                    }
+            })
+        });
+        let drop_notification = std::mem::take(&mut link.drop_next_notification);
+        let tx = link.subscriptions.get(&char_uuid).cloned();
+        drop(link);
+        async move {
+            if !supported {
+                return Err(BlewError::NotifyKindMismatch {
+                    char_uuid,
+                    requested: kind,
+                });
+            }
+            if !drop_notification {
+                // Silently discarding the notification, as if it were lost in
+                // transit, is only armed by `drop_next_notification`.
+                if let Some(tx) = tx {
+                    let _ = tx.send(Bytes::from(value));
+                }
+            }
+            Ok(())
         }
-        async { Ok(()) }
     }
 
     fn l2cap_listener(
@@ -1137,6 +1168,7 @@ mod tests {
             .notify_characteristic(
                 &crate::types::DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"notify-data".to_vec(),
             )
             .await
@@ -1483,6 +1515,7 @@ mod tests {
             .notify_characteristic(
                 &crate::types::DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"too-early".to_vec(),
             )
             .await
@@ -1504,6 +1537,7 @@ mod tests {
             .notify_characteristic(
                 &crate::types::DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"after-sub".to_vec(),
             )
             .await
@@ -1571,6 +1605,7 @@ mod tests {
             .notify_characteristic(
                 &crate::types::DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"after-disconnect".to_vec(),
             )
             .await
@@ -1723,6 +1758,7 @@ mod tests {
                 .notify_characteristic(
                     &crate::types::DeviceId::from("mock-central"),
                     char_uuid,
+                    NotifyKind::Notify,
                     vec![i],
                 )
                 .await
@@ -2238,6 +2274,7 @@ mod tests {
             .notify_characteristic(
                 &DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"dropped".to_vec(),
             )
             .await
@@ -2246,6 +2283,7 @@ mod tests {
             .notify_characteristic(
                 &DeviceId::from("mock-central"),
                 char_uuid,
+                NotifyKind::Notify,
                 b"delivered".to_vec(),
             )
             .await
@@ -2262,6 +2300,122 @@ mod tests {
             }
         };
         assert_eq!(&delivered[..], b"delivered");
+    }
+
+    #[tokio::test]
+    async fn contract_notify_kind_mismatch_is_typed_error() {
+        let (_, p) = MockLink::pair();
+        let peripheral = Peripheral::from_backend(p.peripheral);
+
+        let notify_only = Uuid::from_u128(0xAA01);
+        let indicate_only = Uuid::from_u128(0xAA02);
+        peripheral
+            .add_service(&GattService {
+                uuid: Uuid::from_u128(0x1234),
+                primary: true,
+                characteristics: vec![
+                    GattCharacteristic {
+                        uuid: notify_only,
+                        properties: CharacteristicProperties::NOTIFY,
+                        permissions: AttributePermissions::READ,
+                        value: vec![],
+                        descriptors: vec![],
+                    },
+                    GattCharacteristic {
+                        uuid: indicate_only,
+                        properties: CharacteristicProperties::INDICATE,
+                        permissions: AttributePermissions::READ,
+                        value: vec![],
+                        descriptors: vec![],
+                    },
+                ],
+            })
+            .await
+            .unwrap();
+
+        let device_id = DeviceId::from("mock-central");
+        let err = peripheral
+            .notify_characteristic(&device_id, notify_only, NotifyKind::Indicate, vec![1])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BlewError::NotifyKindMismatch {
+                char_uuid,
+                requested: NotifyKind::Indicate,
+            } if char_uuid == notify_only
+        ));
+
+        let err = peripheral
+            .notify_characteristic(&device_id, indicate_only, NotifyKind::Notify, vec![1])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BlewError::NotifyKindMismatch {
+                char_uuid,
+                requested: NotifyKind::Notify,
+            } if char_uuid == indicate_only
+        ));
+    }
+
+    #[tokio::test]
+    async fn contract_notify_indicate_delivers_to_subscriber() {
+        let (c, p) = MockLink::pair();
+        let central = Central::from_backend(c.central);
+        let peripheral = Peripheral::from_backend(p.peripheral);
+
+        let char_uuid = Uuid::from_u128(0xAA03);
+        peripheral
+            .add_service(&GattService {
+                uuid: Uuid::from_u128(0x1234),
+                primary: true,
+                characteristics: vec![GattCharacteristic {
+                    uuid: char_uuid,
+                    properties: CharacteristicProperties::INDICATE,
+                    permissions: AttributePermissions::READ,
+                    value: vec![],
+                    descriptors: vec![],
+                }],
+            })
+            .await
+            .unwrap();
+        let device_id = DeviceId::from("mock-peripheral");
+        central.connect(&device_id).await.unwrap();
+
+        let mut events = central.events();
+        assert!(matches!(
+            events.next().await.unwrap(),
+            CentralEvent::AdapterStateChanged { powered: true }
+        ));
+        assert!(matches!(
+            events.next().await.unwrap(),
+            CentralEvent::DeviceConnected { .. }
+        ));
+
+        central
+            .subscribe_characteristic(&device_id, char_uuid)
+            .await
+            .unwrap();
+
+        peripheral
+            .notify_characteristic(
+                &DeviceId::from("mock-central"),
+                char_uuid,
+                NotifyKind::Indicate,
+                b"indicated".to_vec(),
+            )
+            .await
+            .unwrap();
+
+        let ev = tokio::time::timeout(std::time::Duration::from_millis(100), events.next())
+            .await
+            .expect("should receive indication")
+            .expect("stream should not end");
+        assert!(matches!(
+            ev,
+            CentralEvent::CharacteristicNotification { value, .. } if &value[..] == b"indicated"
+        ));
     }
 
     use proptest::collection::vec as prop_vec;

--- a/crates/blew/src/testing.rs
+++ b/crates/blew/src/testing.rs
@@ -727,29 +727,38 @@ impl PeripheralBackend for MockPeripheral {
         value: Vec<u8>,
     ) -> impl Future<Output = BlewResult<()>> + Send {
         let mut link = self.link.lock();
-        // Mirror the real backends: an unsupported kind is a typed error, not
-        // a silent wire-format mismatch.
-        let supported = link.services.iter().any(|svc| {
-            svc.characteristics.iter().any(|ch| {
-                ch.uuid == char_uuid
-                    && match kind {
-                        NotifyKind::Notify => {
-                            ch.properties.contains(CharacteristicProperties::NOTIFY)
-                        }
-                        NotifyKind::Indicate => {
-                            ch.properties.contains(CharacteristicProperties::INDICATE)
-                        }
+        // Mirror the real backends: an unknown characteristic is a
+        // LocalCharacteristicNotFound; a known one whose properties don't
+        // support the requested kind is a typed NotifyKindMismatch.
+        let (found, kind_ok) = match link
+            .services
+            .iter()
+            .flat_map(|svc| &svc.characteristics)
+            .find(|ch| ch.uuid == char_uuid)
+        {
+            Some(ch) => {
+                let ok = match kind {
+                    NotifyKind::Notify => ch.properties.contains(CharacteristicProperties::NOTIFY),
+                    NotifyKind::Indicate => {
+                        ch.properties.contains(CharacteristicProperties::INDICATE)
                     }
-            })
-        });
+                };
+                (true, ok)
+            }
+            None => (false, false),
+        };
         let drop_notification = std::mem::take(&mut link.drop_next_notification);
         let tx = link.subscriptions.get(&char_uuid).cloned();
         drop(link);
         async move {
-            if !supported {
-                return Err(BlewError::NotifyKindMismatch {
-                    char_uuid,
-                    requested: kind,
+            if !kind_ok {
+                return Err(if found {
+                    BlewError::NotifyKindMismatch {
+                        char_uuid,
+                        requested: kind,
+                    }
+                } else {
+                    BlewError::LocalCharacteristicNotFound { char_uuid }
                 });
             }
             if !drop_notification {
@@ -2356,6 +2365,38 @@ mod tests {
                 char_uuid,
                 requested: NotifyKind::Notify,
             } if char_uuid == indicate_only
+        ));
+    }
+
+    #[tokio::test]
+    async fn contract_notify_unknown_characteristic_is_typed_error() {
+        let (_, p) = MockLink::pair();
+        let peripheral = Peripheral::from_backend(p.peripheral);
+
+        peripheral
+            .add_service(&GattService {
+                uuid: Uuid::from_u128(0x1234),
+                primary: true,
+                characteristics: vec![GattCharacteristic {
+                    uuid: Uuid::from_u128(0xAA01),
+                    properties: CharacteristicProperties::NOTIFY,
+                    permissions: AttributePermissions::READ,
+                    value: vec![],
+                    descriptors: vec![],
+                }],
+            })
+            .await
+            .unwrap();
+
+        let device_id = DeviceId::from("mock-central");
+        let unknown = Uuid::from_u128(0xBEEF);
+        let err = peripheral
+            .notify_characteristic(&device_id, unknown, NotifyKind::Notify, vec![1])
+            .await
+            .unwrap_err();
+        assert!(matches!(
+            err,
+            BlewError::LocalCharacteristicNotFound { char_uuid } if char_uuid == unknown
         ));
     }
 


### PR DESCRIPTION
## What

Implements issues #18 (per-call notify vs. indicate) and #9 (surface indication confirmations), landed together as the maintainer requested in both issue threads.

`Peripheral::notify_characteristic` now takes a `NotifyKind::{Notify, Indicate}` argument. `NotifyKind::Indicate` sends an ATT Handle Value Indication and its completion is a real delivery acknowledgement.

## Changes

- **API**: `notify_characteristic(device_id, char_uuid, NotifyKind, value)` + new `BlewError::NotifyKindMismatch { char_uuid, requested }`.
- **Android**: `confirm` derives from the kind; resolves only when `onNotificationSent` fires (true ACK). New `nativeOnNotificationSent` JNI hook; calls are seq-tagged (monotonic) so a busy-retry can never resolve a newer call with an older callback; 5s backstop for stacks that never report.
- **Linux**: characteristics declaring `INDICATE` now register an indication CCCD; BlueZ resolves the notifier after the peer confirms an indication.
- **Apple**: validates the characteristic property and returns the typed mismatch error (CoreBluetooth has no per-indication ACK; completion = queue acceptance).
- **Mock**: mirrors the validation with contract tests.

## Verification

- `cargo test --workspace` (includes 2 new indication/kind contract tests)
- `cargo clippy --workspace -- -D warnings` and `cargo fmt --all -- --check`
- `cargo check --target aarch64-linux-android` (blew + tauri-plugin-blew)
- CHANGELOG updated with an upgrade guide snippet.

Fixes #18. Fixes #9.